### PR TITLE
Remove redundant test in orient2d for better branch predictability.

### DIFF
--- a/src/orient2d.js
+++ b/src/orient2d.js
@@ -57,8 +57,6 @@ export function orient2d(ax, ay, bx, by, cx, cy) {
     const detright = (ax - cx) * (by - cy);
     const det = detleft - detright;
 
-    if (detleft === 0 || detright === 0 || (detleft > 0) !== (detright > 0)) return det;
-
     const detsum = Math.abs(detleft + detright);
     if (Math.abs(det) >= ccwerrboundA * detsum) return det;
 


### PR DESCRIPTION
This removes the test in orient2d for `detleft === 0 || detright === 0 || (detleft >0) !== (detright >0)`. The rationale is the following: If either of those conditions is true, then the next test `if (Math.abs(det) >= ccwerrboundA * detsum)` is always true (in each of those cases `abs(det) == abs(detleft) + abs(detright) >= detsum` is true and ccwerrboundA is smaller than 1).

But the second test is most of the time true generally while the first should be true for roughly 50% of cases, so removing the first should work better with branch prediction on a modern CPU aside from removing the work for the first test. I tried measuring this with delaunator and saw ~5% speed gain averaged over 10 bench runs but I have no experience with Node benchmarking so that figure should be taken with a grain of salt.